### PR TITLE
Vnode hooks and input signals by @roryc89

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ main = do
   H.mount "main" {
     init: init :> [],
     update: \msg model -> update msg model :> [],
-    view
+    view,
+    inputs: []
   }
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "purescript-web-dom": "^1.0.0",
     "purescript-web-html": "^1.0.0",
     "purescript-nullable": "^4.0.0",
-    "purescript-aff": "^5.0.1"
+    "purescript-aff": "^5.0.1",
+    "purescript-signal": "^10.1.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/src/Hedwig/Foreign.js
+++ b/src/Hedwig/Foreign.js
@@ -103,10 +103,8 @@ const unwrapEff1 = function(fn) {
 };
 
 const unwrapEff2 = function(fn) {
-  return function(oldVnode) {
-    return function (newVnode) {
-      return fn(oldVnode)(newVnode)()
-    };
+  return function(oldVnode, newVnode) {
+    return fn(oldVnode)(newVnode)()
   };
 };
 

--- a/src/Hedwig/Foreign.js
+++ b/src/Hedwig/Foreign.js
@@ -37,6 +37,7 @@ const KEY = 4;
 const STYLE = 5;
 const TRANSITION = 6;
 const TRANSITION_GROUP = 7;
+const HOOK1 = 8;
 
 exports.attribute_ = function(name, value) {
   return [ATTRIBUTE, name, value];
@@ -78,6 +79,10 @@ exports.transitionGroup__ = function(o) {
   return [TRANSITION_GROUP, o];
 };
 
+exports.hook1_ = function(name, fn) {
+  return [HOOK1, name, fn];
+};
+
 const call = function(send, msg, event) {
   send(msg(event)())();
 };
@@ -85,6 +90,12 @@ const call = function(send, msg, event) {
 const call_ = function(send, msg, _event) {
   send(msg)();
 };
+
+const unwrapEff1 = function(fn) {
+  return function(vnode) {
+    return fn(vnode)()
+  }
+}
 
 const toVnode = function(html, send) {
   if (typeof html === 'string') {
@@ -126,6 +137,9 @@ const toVnode = function(html, send) {
             data.on = data.on || {};
             data.on[trait[1]] = [call_, send, trait[2]];
             break;
+          case HOOK1:
+            data.hook = data.hook || {};
+            data.hook[trait[1]] = unwrapEff(trait[2]);
           case KEY:
             data.key = trait[1];
             break;

--- a/src/Hedwig/Foreign.js
+++ b/src/Hedwig/Foreign.js
@@ -38,6 +38,7 @@ const STYLE = 5;
 const TRANSITION = 6;
 const TRANSITION_GROUP = 7;
 const HOOK1 = 8;
+const HOOK2 = 9;
 
 exports.attribute_ = function(name, value) {
   return [ATTRIBUTE, name, value];
@@ -83,6 +84,10 @@ exports.hook1_ = function(name, fn) {
   return [HOOK1, name, fn];
 };
 
+exports.hook2_ = function(name, fn) {
+  return [HOOK2, name, fn];
+};
+
 const call = function(send, msg, event) {
   send(msg(event)())();
 };
@@ -95,7 +100,15 @@ const unwrapEff1 = function(fn) {
   return function(vnode) {
     return fn(vnode)()
   }
-}
+};
+
+const unwrapEff2 = function(fn) {
+  return function(oldVnode) {
+    return function (newVnode) {
+      return fn(oldVnode)(newVnode)()
+    };
+  };
+};
 
 const toVnode = function(html, send) {
   if (typeof html === 'string') {
@@ -139,7 +152,12 @@ const toVnode = function(html, send) {
             break;
           case HOOK1:
             data.hook = data.hook || {};
-            data.hook[trait[1]] = unwrapEff(trait[2]);
+            data.hook[trait[1]] = unwrapEff1(trait[2]);
+            break;
+          case HOOK2:
+            data.hook = data.hook || {};
+            data.hook[trait[1]] = unwrapEff2(trait[2]);
+            break;
           case KEY:
             data.key = trait[1];
             break;

--- a/src/Hedwig/Foreign.purs
+++ b/src/Hedwig/Foreign.purs
@@ -13,6 +13,11 @@ foreign import data Html :: Type -> Type
 
 foreign import data Trait :: Type -> Type
 
+foreign import data VirtualNode :: Type -> Type
+
+type VNodeFn1 msg = VirtualNode msg -> Effect Unit
+type VNodeFn2 msg = VirtualNode msg -> VirtualNode msg -> Effect Unit
+
 foreign import element_ :: forall msg. Fn3 String (Array (Trait msg)) (Array (Html msg)) (Html msg)
 foreign import text_ :: forall msg. Fn1 String (Html msg)
 foreign import mapHtml_ :: forall a b. Fn2 (a -> b) (Html a) (Html b)
@@ -31,8 +36,8 @@ foreign import transition_ :: forall msg. Fn1 String (Trait msg)
 foreign import transition__ :: forall msg. Fn1 TransitionOptions (Trait msg)
 foreign import transitionGroup_ :: forall msg. Fn1 String (Trait msg)
 foreign import transitionGroup__ :: forall msg. Fn1 TransitionOptions (Trait msg)
-
-foreign import data VirtualNode :: Type -> Type
+foreign import hook1_ :: forall msg. Fn2 String (VNodeFn1 msg) (Trait msg)
+-- TODO: foreign import hook2_ :: forall msg. Fn2 String (VNodeFn2 msg) (Trait msg)
 
 foreign import patch0_ :: forall msg. EffectFn3 Element (Html msg) (msg -> Effect Unit) (VirtualNode msg)
 foreign import patch_ :: forall msg. EffectFn3 (VirtualNode msg) (Html msg) (msg -> Effect Unit) (VirtualNode msg)
@@ -98,6 +103,14 @@ patch0 = runEffectFn3 patch0_
 
 patch :: forall msg. VirtualNode msg -> Html msg -> (msg -> Effect Unit) -> Effect (VirtualNode msg)
 patch = runEffectFn3 patch_
+
+-- | Attach an unary vnode function as a hook
+hook1 :: forall msg. String -> VNodeFn1 msg -> Trait msg
+hook1 = runFn2 hook1_
+
+-- -- | Attach a binary vnode function as a hook
+-- hook2 :: forall msg. String -> VNodeFn2 msg -> Trait msg
+-- hook2 = runFn2 hook2_
 
 log :: forall a. a -> Effect Unit
 log = runEffectFn1 log_

--- a/src/Hedwig/Foreign.purs
+++ b/src/Hedwig/Foreign.purs
@@ -37,7 +37,7 @@ foreign import transition__ :: forall msg. Fn1 TransitionOptions (Trait msg)
 foreign import transitionGroup_ :: forall msg. Fn1 String (Trait msg)
 foreign import transitionGroup__ :: forall msg. Fn1 TransitionOptions (Trait msg)
 foreign import hook1_ :: forall msg. Fn2 String (VNodeFn1 msg) (Trait msg)
--- TODO: foreign import hook2_ :: forall msg. Fn2 String (VNodeFn2 msg) (Trait msg)
+foreign import hook2_ :: forall msg. Fn2 String (VNodeFn2 msg) (Trait msg)
 
 foreign import patch0_ :: forall msg. EffectFn3 Element (Html msg) (msg -> Effect Unit) (VirtualNode msg)
 foreign import patch_ :: forall msg. EffectFn3 (VirtualNode msg) (Html msg) (msg -> Effect Unit) (VirtualNode msg)
@@ -108,9 +108,9 @@ patch = runEffectFn3 patch_
 hook1 :: forall msg. String -> VNodeFn1 msg -> Trait msg
 hook1 = runFn2 hook1_
 
--- -- | Attach a binary vnode function as a hook
--- hook2 :: forall msg. String -> VNodeFn2 msg -> Trait msg
--- hook2 = runFn2 hook2_
+-- | Attach a binary vnode function as a hook
+hook2 :: forall msg. String -> VNodeFn2 msg -> Trait msg
+hook2 = runFn2 hook2_
 
 log :: forall a. a -> Effect Unit
 log = runEffectFn1 log_

--- a/src/Hedwig/Hook.purs
+++ b/src/Hedwig/Hook.purs
@@ -2,10 +2,10 @@ module Hedwig.Hook
  ( atInit
  , atInsert
  , atDestroy
- -- , atCreate
- -- , atPrepatch
- -- , atUpdate
- -- , atPostPatch
+ , atCreate
+ , atPrepatch
+ , atUpdate
+ , atPostPatch
  , module Virtual
  ) where
 
@@ -37,7 +37,7 @@ atUpdate :: forall msg. VNodeFn2 msg -> Trait msg
 atUpdate = hook2 "update"
 
 -- | Attaches a hook for vnode element postpatch
-atPostpatch :: forall msg. VNodeFn2 msg -> Trait msg
-atPostpatch = hook2 "postpatch"
+atPostPatch :: forall msg. VNodeFn2 msg -> Trait msg
+atPostPatch = hook2 "postpatch"
 
 -- TODO: remove; an element is directly being removed from the DOM; vnode, removeCallback

--- a/src/Hedwig/Hook.purs
+++ b/src/Hedwig/Hook.purs
@@ -5,7 +5,7 @@ module Hedwig.Hook
  , atCreate
  , atPrepatch
  , atUpdate
- , atPostPatch
+ , atPostpatch
  , module Virtual
  ) where
 
@@ -37,7 +37,7 @@ atUpdate :: forall msg. VNodeFn2 msg -> Trait msg
 atUpdate = hook2 "update"
 
 -- | Attaches a hook for vnode element postpatch
-atPostPatch :: forall msg. VNodeFn2 msg -> Trait msg
-atPostPatch = hook2 "postpatch"
+atPostpatch :: forall msg. VNodeFn2 msg -> Trait msg
+atPostpatch = hook2 "postpatch"
 
 -- TODO: remove; an element is directly being removed from the DOM; vnode, removeCallback

--- a/src/Hedwig/Hook.purs
+++ b/src/Hedwig/Hook.purs
@@ -1,0 +1,31 @@
+module Hedwig.Hook
+ ( atInit
+ , atInsert
+ , atDestroy
+ -- , atCreate
+ -- , atPrepatch
+ -- , atUpdate
+ -- , atPostPatch
+ , module Virtual
+ ) where
+
+import Hedwig.Foreign (hook1, VNodeFn1, Trait)
+import Hedwig.Foreign (VirtualNode, VNodeFn1, VNodeFn2) as Virtual
+
+-- | Attaches a hook for vnode init (a vnode has been added)
+atInit :: forall msg. VNodeFn1 msg -> Trait msg
+atInit = hook1 "init"
+
+-- | Attaches a hook for vnode DOM insertion
+atInsert :: forall msg. VNodeFn1 msg -> Trait msg
+atInsert = hook1 "insert"
+
+-- | Attaches a hook for vnode destruction
+atDestroy :: forall msg. VNodeFn1 msg -> Trait msg
+atDestroy = hook1 "destroy"
+
+-- TODO: create; a DOM element has been created based on a vnode; emptyVnode, vnode
+-- TODO: prepatch; an element is about to be patched; oldVnode, vnode
+-- TODO: update; an element is being updated; oldVnode, vnode
+-- TODO: postpatch; an element has been patched; oldVnode, vnode
+-- TODO: remove; an element is directly being removed from the DOM; vnode, removeCallback

--- a/src/Hedwig/Hook.purs
+++ b/src/Hedwig/Hook.purs
@@ -9,7 +9,7 @@ module Hedwig.Hook
  , module Virtual
  ) where
 
-import Hedwig.Foreign (hook1, VNodeFn1, Trait)
+import Hedwig.Foreign (hook1, hook2, VNodeFn1, VNodeFn2, Trait)
 import Hedwig.Foreign (VirtualNode, VNodeFn1, VNodeFn2) as Virtual
 
 -- | Attaches a hook for vnode init (a vnode has been added)
@@ -24,8 +24,20 @@ atInsert = hook1 "insert"
 atDestroy :: forall msg. VNodeFn1 msg -> Trait msg
 atDestroy = hook1 "destroy"
 
--- TODO: create; a DOM element has been created based on a vnode; emptyVnode, vnode
--- TODO: prepatch; an element is about to be patched; oldVnode, vnode
--- TODO: update; an element is being updated; oldVnode, vnode
--- TODO: postpatch; an element has been patched; oldVnode, vnode
+-- | Attaches a hook for vnode-based DOM element creation
+atCreate :: forall msg. VNodeFn2 msg -> Trait msg
+atCreate = hook2 "create"
+
+-- | Attaches a hook for vnode element prepatch
+atPrepatch :: forall msg. VNodeFn2 msg -> Trait msg
+atPrepatch = hook2 "prepatch"
+
+-- | Attaches a hook for vnode element update
+atUpdate :: forall msg. VNodeFn2 msg -> Trait msg
+atUpdate = hook2 "update"
+
+-- | Attaches a hook for vnode element postpatch
+atPostpatch :: forall msg. VNodeFn2 msg -> Trait msg
+atPostpatch = hook2 "postpatch"
+
 -- TODO: remove; an element is directly being removed from the DOM; vnode, removeCallback


### PR DESCRIPTION
Should have opened it a long ago, but I've implemented basic vnode hooks (except for remove), which can be useful for some custom element injection (I've done a Markdown renderer port from Elm using these).

All hooks are put in `Hedwig.Hook` module and have `Trait msg` type. Now they are mostly suited for foreign functions, as `VirtualNode` is foreign itself.

Also, including #6 by @roryc89, because it was field-tested by us and works well for sure.